### PR TITLE
fix: inline tags for compact mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports = class OwnerTag extends Plugin {
                     res,
                     e =>
                         Array.isArray(e.props?.children) &&
-                        e.props.children.find(c => c.props?.message)
+                        e.props.children.find(c => c?.props?.message)
                 );
                 let data;
 


### PR DESCRIPTION
unsure if this was broke on cosy, didn't test. however, this is just a null-coalescing check for the index